### PR TITLE
Capture and return ExtendScript return values from run tool

### DIFF
--- a/illustrator/server.py
+++ b/illustrator/server.py
@@ -184,11 +184,12 @@ def run_illustrator_script(code: str) -> list[types.TextContent]:
             jsx_file_path = jsx_file.name
         logging.debug(f"ExtendScript saved to: {jsx_file_path}")
         illustrator = win32com.client.Dispatch("Illustrator.Application")
-        illustrator.DoJavaScriptFile(jsx_file_path)
+        result = illustrator.DoJavaScriptFile(jsx_file_path)
         logging.info("ExtendScript executed successfully.")
         os.unlink(jsx_file_path)
         logging.debug("Temporary ExtendScript file removed.")
-        return [types.TextContent(type="text", text="Script executed successfully")]
+        result_text = str(result) if result is not None else "Script executed successfully (no return value)"
+        return [types.TextContent(type="text", text=result_text)]
     except Exception as e:
         logging.error(f"Failed to execute script: {str(e)}")
         return [types.TextContent(type="text", text=f"Failed to execute script: {str(e)}")]


### PR DESCRIPTION
## Summary

- Captures the return value of `DoJavaScriptFile` instead of discarding it, so ExtendScript code can return data back to the MCP client
- Returns the stringified result when present, or a descriptive "no return value" message when the script doesn't return anything
- Previously the `run` tool always returned a static `"Script executed successfully"` message regardless of what the script produced

## Motivation

Without this change, the only way to observe script output is through side effects (e.g. creating objects on the artboard). Capturing return values enables querying document state, reading properties, computing values, and any other use case where the caller needs data back from ExtendScript — which is essential for effective MCP tool use.

## Test plan

- [ ] Run a script that returns a value (e.g. `app.documents.length`) and verify the value appears in the tool response
- [ ] Run a script with no return value and verify the response says "Script executed successfully (no return value)"
- [ ] Run a script that errors and verify the error message is still returned correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)